### PR TITLE
No pointer events on mobile sidebar when closed

### DIFF
--- a/source/style/_theme/layout.less
+++ b/source/style/_theme/layout.less
@@ -60,6 +60,9 @@ body {
   .content {
     .transition(all 300ms @easing);
   }
+  .sidebar {
+    pointer-events: none;
+  }
   .sidebar,
   .sidebar-content {
     .transition(all 300ms @easing);
@@ -67,6 +70,7 @@ body {
 
   &.sidebar-visible {
     .sidebar {
+      pointer-events: auto;
       .transform(translateX(0));
 
       .sidebar-content {


### PR DESCRIPTION
@SachaG says this should fix #34. I can't repro, so I'm not sure. But at least it doesn't break anything 😊