### PR TITLE
Update calculation of sidebar scroll for non-root urls

### DIFF
--- a/source/script/main.js
+++ b/source/script/main.js
@@ -155,12 +155,18 @@
     }
   }
 
-
   // scroll sidebar page link into view on page load (except for the top link)
-  var atRoot = location.pathname === '/' || location.pathname === '/index.html';
+
+  // Careful, this commented code will not work due to the redirection of the root
+  // var atRoot = location.pathname === '/' || location.pathname === '/index.html'
+
+  var allSidebarLinks = document.querySelectorAll('.item-toc a.sidebar-link');
+  var currentSideBarLink = document.querySelector('.item-toc a[href=""]');
+
+  var atRoot = allSidebarLinks[0] === currentSideBarLink;
   if (!atRoot || location.hash !== '') {
     // hexo rewrites the URLs to be relative, so the current page has href="".
-    document.querySelector('.item-toc a[href=""]').scrollIntoView();
+    currentSideBarLink.scrollIntoView();
   }
 
   function findCurrentVersion() {


### PR DESCRIPTION
For doc sites such as [Apollo Link](https://www.apollographql.com/docs/link/), the sidebar scroll hides the searchbox, since the `location.pathname` is `/docs/link/` rather than `/`. The new calculation also works on the [meteor docs](https://docs.meteor.com/), at least in the console 😜.

`document.querySelectorAll('.item-toc a.sidebar-link')[0] === document.querySelector('.item-toc a[href=""]')` for your convenience