### PR TITLE
Re-instate inadvertently removed background color on inline `<code>`.

### DIFF
--- a/source/style/_global/base.less
+++ b/source/style/_global/base.less
@@ -65,6 +65,9 @@ pre {
 }
 
 code {
+	&:not([class*="language-"]) {
+		background: @color-light;
+	}
 	display: inline-block;
 	padding-left: 2px;
 	padding-right: 2px;


### PR DESCRIPTION
This regression to the style occurred in [exhibit A] during the implementation of
Prism code snippet highlighting, which provides its own styles for multi-line
`<code>`-blocks, but doesn't do anything for inline blocks (by design).

[exhibit A]: https://github.com/meteor/meteor-theme-hexo/commit/c0614e86d0b75211d4cddde1c17346627fbf9621
Fixes: https://github.com/meteor/meteor-theme-hexo/issues/63