### PR TITLE
Separate each `script` tag into its own context to limit error scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNEXT
 
+* Separates various JavaScript snippets into their own context to avoid errors
+  from affecting other scripts.
+  [PR #](https://github.com/meteor/meteor-theme-hexo/pull/)
+
 ## v1.0.5
 
 * The search box is now pinned to the menu and won't scroll off the page when

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -99,8 +99,10 @@
         a.src = 'https://nectar.ninja/api/v1/' + handle.slice(1);
         m.parentNode.insertBefore(a, m);
       })();
+    </script>
 
-     <% if (config.apis && config.apis.ga) { %>
+    <% if (config.apis && config.apis.ga) { %>
+      <script>
         // Google analytics
         ;(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -109,24 +111,30 @@
 
         ga('create', '<%- config.apis.ga %>', 'auto');
         ga('send', 'pageview');
-      <% } %>
+      </script>
+    <% } %>
 
-      <% if (config.apis && config.apis.segment) { %>
+    <% if (config.apis && config.apis.segment) { %>
+      <script>
         // Segment Tracking
         !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
         analytics.load("<%- config.apis.segment %>");
         analytics.page()
         }}();
-      <% } %>
+      </script>
+    <% } %>
 
-      // search box
-      <% if (config.apis && config.apis.swiftype) { %>
+    // search box
+    <% if (config.apis && config.apis.swiftype) { %>
+      <script>
         ;(function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
         (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
         e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
         })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
         _st('install','<%- config.apis.swiftype %>','2.0.0');
-      <% } else if (config.apis && config.apis.docsearch) { %>
+      </script>
+    <% } else if (config.apis && config.apis.docsearch) { %>
+      <script>
         ['desktop'].forEach(function(type) {
           var search = docsearch({
             apiKey: '<%- config.apis.docsearch.apiKey %>',
@@ -161,9 +169,11 @@
             }
           });
         });
-      <% } %>
+      </script>
+    <% } %>
 
-      <% if (config.redirects) { %>
+    <% if (config.redirects) { %>
+      <script>
         var REDIRECTS = <%- JSON.stringify(config.redirects, 0, 2) %>;
 
         function redirect() {
@@ -185,7 +195,7 @@
 
         // Redirect on hash change
         window.onhashchange = redirect;
-      <% } %>
-    </script>
+      </script>
+    <% } %>
   </body>
 </html>


### PR DESCRIPTION
Unfortunately, a result of the problem reported in #65 is that all other
JavaScript, including search, was prevented from working because they all
lived in a shared `<script>` tag.  This change puts each concern in its own
`<script>` tag to isolate the damage by those script tags.

Of course, each of the script providers would have had this in their own
code-snippets they offer for copy-pasting, but I guess we decided to put
them all in a single `<script>` tag at one point. :cry:

Ref: https://github.com/meteor/meteor-theme-hexo/pull/65
Ref: https://github.com/meteor/meteor-theme-hexo/pull/65/commits/544f1f408