### PR TITLE
Introduce support for the dropdown to change versions on non-/ deployments.

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -83,7 +83,13 @@
     <script type="text/javascript" src="<%= prismSyntaxJsUrl %>"></script>
 
     <script type="text/javascript" src="//cdn.jsdelivr.net/npm/smooth-scroll@12.1.5/dist/js/smooth-scroll.min.js"></script>
+
+    <script>
+      // Used by the main.js script below.
+      docsConfigRoot = '<%- config.root %>';
+    </script>
     <script src="<%= url_for('script/main.js', { relative: true }) %>"></script>
+
     <% if (config.apis && config.apis.docsearch) { %>
       <script type="text/javascript" src="//cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
     <% } %>

--- a/source/script/main.js
+++ b/source/script/main.js
@@ -12,6 +12,8 @@
   var forEach = Array.prototype.forEach;
   var some = Array.prototype.some;
 
+  docsConfigRoot = docsConfigRoot || '/';
+
   var escapeEntityMap = {
     '&': '&amp;',
     '<': '&lt;',
@@ -168,7 +170,12 @@
     // https://docs.domain.com/v1.2.3
     // https://docs.domain.com/v1.2.3/
     // https://docs.domain.com/v1.2.3/api/email.html
-    var versionInPath = location.pathname.match(/^\/v(\d[^\/]+)/);
+
+    var rootPath = docsConfigRoot.replace(/\/+$/g, '/');
+
+    var pathVersionRegExp = new RegExp('^' + rootPath + 'v(\\d[^\/]\+)', 'i');
+
+    var versionInPath = location.pathname.match(pathVersionRegExp);
     if (versionInPath && versionInPath[1]) {
       return versionInPath[1];
     }
@@ -197,9 +204,9 @@
     }
 
     select.addEventListener('change', function () {
-      var targetPath = '/'
+      var targetPath = docsConfigRoot;
       if (select.selectedIndex !== 0) {
-        targetPath = '/' + select.value + '/'
+        targetPath = targetPath + select.value + '/'
       }
       location.assign(targetPath)
     })


### PR DESCRIPTION
Previously, the dropdown assumed that the docs were deployed at the top level of the URI, for example example.com, not example.com/docs/server/.  

This introduces an awareness of the configured "Root" path, as defined in `_config.yml`.