### PR TITLE
Allow the "Edit on GitHub" button to support version branches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNEXT
 
+* Allow the "Edit on GitHub" button to work on "versioned" documentation.
+  [PR #TODO](https://github.com/meteor/meteor-theme-hexo/pull/TODO)
+
 ## v1.0.13
 
 * Align headings with tiered structure content.

--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -1,6 +1,15 @@
-<% var githubUrl = 'https://github.com/' + config.github_repo +
-    '/tree/master/' + (config.content_root || 'content') + '/' +
-    page.path.replace(/\.html$/, '.md'); %>
+  <%
+    var githubUrl =
+      'https://github.com/' +
+      config.github_repo +
+      '/tree/' +
+      // If on a version, use the `version-X` branch, not `master`.
+      (config.version ? 'version-' + config.version : 'master') +
+      '/' +
+      (config.content_root || 'content') +
+      '/' +
+      page.path.replace(/\.html$/, '.md');
+  %>
 
   <div class="nav <%- config.nav_class %>">
     <div class="nav-group left">


### PR DESCRIPTION
This requires setting the `version` in the configuration so the static
generator can generate the correct links, but will gracefully fall back to
the state it was in before (which means, not working for version branches
and working totally normal for the primary version) if that's not set.