### PR TITLE
Updates for Prismjs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNEXT
 
+* Update Prism version to 1.15.0.
+  [PR #TODO](https://github.com/meteor/meteor-theme-hexo/pull/TODO)
+
 ## v1.0.14
 
 * Allow the "Edit on GitHub" button to work on "versioned" documentation.

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -37,7 +37,7 @@
 
     <%# We use Prism for syntax highlighting.  Be sure to check out the JS in BODY, below, too! %>
     <%
-      prismVersion = "1.13.0";
+      prismVersion = "1.15.0";
       prismBase = "//cdn.jsdelivr.net/npm/prismjs@" + prismVersion;
       prismFlavors = [
         "bash",

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -49,9 +49,9 @@
         "typescript"
       ]
     %>
-    <link href='//cdn.jsdelivr.net/npm/prismjs@1.13.0/themes/prism.min.css' rel='stylesheet' type='text/css'>
-    <link href='//cdn.jsdelivr.net/npm/prismjs@1.13.0/plugins/line-numbers/prism-line-numbers.min.css' rel='stylesheet' type='text/css'>
-    <link href='//cdn.jsdelivr.net/npm/prismjs@1.13.0/plugins/line-highlight/prism-line-highlight.css' rel='stylesheet' type='text/css'>
+    <link href='//cdn.jsdelivr.net/npm/prismjs@<%= prismVersion %>/themes/prism.min.css' rel='stylesheet' type='text/css'>
+    <link href='//cdn.jsdelivr.net/npm/prismjs@<%= prismVersion %>/plugins/line-numbers/prism-line-numbers.min.css' rel='stylesheet' type='text/css'>
+    <link href='//cdn.jsdelivr.net/npm/prismjs@<%= prismVersion %>/plugins/line-highlight/prism-line-highlight.css' rel='stylesheet' type='text/css'>
 
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,200,300italic,400italic' rel='stylesheet' type='text/css'>
     <% if (config.css_bundle) {  %>


### PR DESCRIPTION
```
 f5ef264 (Jesse Rosenberger, 17 seconds ago)
    Update PrismJS version to 1.15.0.

 7ac0591 (Jesse Rosenberger, 3 minutes ago)
    Change jsdelivr.net prism CDN links to use `prismVersion` variable.
```