### PR TITLE
Make version switcher option color darker

### DIFF
--- a/source/style/_theme/colors.less
+++ b/source/style/_theme/colors.less
@@ -113,6 +113,7 @@
 
       .version-select {
         color: #353c58;
+        font-weight: normal;
       }
     }
 

--- a/source/style/_theme/colors.less
+++ b/source/style/_theme/colors.less
@@ -110,6 +110,10 @@
       .title-sidebar {
         .subheading-caps;
       }
+
+      .version-select {
+        color: #353c58;
+      }
     }
 
     ul.list-toc {


### PR DESCRIPTION
Fixes an issue on IE and in Linux browsers, where the version switcher options weren't showing up as the font color was too light. Thanks!